### PR TITLE
fix: vscode settings not shown in windows

### DIFF
--- a/src/bin/webapp-finalize.js
+++ b/src/bin/webapp-finalize.js
@@ -1,0 +1,49 @@
+const path = require("path");
+const fs   = require("fs");
+
+const webappPath = path.resolve(process.cwd(), 'dist/webview/connection');
+
+let indexHtml  = fs.readFileSync(path.resolve(webappPath, 'index.html')).toString();
+
+function makeInline(config, data) {
+    let currentData = new Buffer.from('', 'utf-8');
+    let isFlagSet = false;
+
+    return data.replace(config.pattern, (match, script) => {
+        const replacement = !isFlagSet ? '###INLINE_CONTENT###' : '';
+        isFlagSet = true;
+
+        const content = fs.readFileSync(path.resolve(webappPath, script));
+        fs.unlinkSync(path.resolve(webappPath, script));
+
+        if (config.isScript && script.indexOf('-es2015') === -1) {
+            return '';
+        }
+
+        currentData = Buffer.concat([currentData, content]);
+        return replacement;
+    }).replace(/###INLINE_CONTENT###/, () =>  {
+        return config.template.replace(/###INLINE_CONTENT###/, currentData.toString());
+    });
+}
+
+[
+    {
+        isScript: true,
+        pattern: /<script src="(.*?)".*?><\/script>/g,
+        template: `<script type="module">
+        ###INLINE_CONTENT###
+    </script>`
+    },
+    {
+        pattern: /<link rel="stylesheet" href="(.*?)".*?>/g,
+        template: `
+        <style type="text/css">
+        ###INLINE_CONTENT###
+    </style>`
+    }
+].forEach((config) => {
+    indexHtml = makeInline(config, indexHtml);
+});
+
+fs.writeFileSync(path.resolve(webappPath, 'index.html'), indexHtml, {flag: "w"});

--- a/src/package.json
+++ b/src/package.json
@@ -15,6 +15,7 @@
     "postinstall": "npm i --prefix ./projects/media/webview",
     "postbuild": "npm run webview:build",
     "webview:build": "npm run build --prefix ./projects/media/webview -- --prod",
+    "postwebview:build": "node ./bin/webapp-finalize.js",
     "webview:dev": "npm start --prefix ./projects/media/webview -- --configuration browser",
     "changelog:compile": "tsc -p ./ci",
     "changelog:generate": "node ./dist/ci/changelog",

--- a/src/projects/media/webview/projects/connection/src/app/ui/edit/edit.html
+++ b/src/projects/media/webview/projects/connection/src/app/ui/edit/edit.html
@@ -1,5 +1,9 @@
-<div [formGroup]="connectionForm" class="form">
+<div class="btn-bar">
+    <button class="btn" type="button" (click)="doSave()">save</button>
+    <button class="btn" type="button" (click)="doCancel()">cancel</button>
+</div>
 
+<div [formGroup]="connectionForm" class="form">
     <!-- label -->
     <h3>Default Settings</h3>
 
@@ -97,10 +101,4 @@
         <vsqlik-settings--form-strategy *ngSwitchDefault>
         </vsqlik-settings--form-strategy>
     </div>
-
-</div>
-
-<div class="footer btn-bar">
-    <button class="btn" type="button" (click)="doSave()">save</button>
-    <button class="btn" type="button" (click)="doCancel()">cancel</button>
 </div>

--- a/src/projects/media/webview/projects/connection/src/app/ui/main/main.component.html
+++ b/src/projects/media/webview/projects/connection/src/app/ui/main/main.component.html
@@ -8,8 +8,7 @@
         </div>
         <div class="actions">
             <button class="btn action" (click)="createSetting()">
-                <i class="vsqlik-icon vsqlik-icon--add"></i>
-                <span class="label">Add Connection</span>
+                <span class="label">Create Connection</span>
             </button>
         </div>
     </header>

--- a/src/projects/media/webview/projects/connection/src/app/ui/main/main.component.scss
+++ b/src/projects/media/webview/projects/connection/src/app/ui/main/main.component.scss
@@ -39,6 +39,7 @@
             overflow: hidden;
             text-overflow: ellipsis;
             padding: .2rem .5rem;
+            align-items: center;
         }
 
         td {
@@ -47,11 +48,17 @@
 
         .action-col {
             display: flex;
-            flex: 0 0 5rem;
+            flex: 0 0 120px;
             overflow: hidden;
+            justify-content: flex-end;
 
             .btn {
                 margin: 0 .25rem 0 0;
+                padding: .5rem;
+            }
+
+            .btn:last-child {
+              margin: 0;
             }
         }
     }
@@ -63,7 +70,7 @@
     }
 
     vsqlik-wfs--table-row-edit ::ng-deep {
-        
+
         td:not(.action-col) {
             padding: 0;
         }

--- a/src/projects/media/webview/projects/connection/src/app/ui/table/table-row.html
+++ b/src/projects/media/webview/projects/connection/src/app/ui/table/table-row.html
@@ -5,7 +5,7 @@
     <td>{{setting.connection?.secure}}</td>
     <td>{{setting.connection?.allowUntrusted}}</td>
     <td class="action-col">
-        <button type="button" class="btn btn-action" (click)="doEdit()"><i class="vsqlik-icon vsqlik-icon--edit"></i></button>
-        <button type="button" class="btn btn-action" (click)="doDelete()"><i class="vsqlik-icon vsqlik-icon--delete"></i></button>
+        <button type="button" class="btn btn-action" (click)="doEdit()">edit</button>
+        <button type="button" class="btn btn-action" (click)="doDelete()">remove</button>
     </td>
 </tr>


### PR DESCRIPTION
in windows we are not allowed to load javascript / css files in the webview, added new script which will run after webview:build process and merge all ess2015 js files and css file into the index.html files.

closes #270