### PR TITLE
fix: fixed bug multiple authorization requests was running

### DIFF
--- a/src/projects/extension/authorization/authorization.helper.ts
+++ b/src/projects/extension/authorization/authorization.helper.ts
@@ -43,8 +43,6 @@ export class AuthorizationHelper {
             return this.connections.get(workspaceFolder);
         }
 
-        console.log(workspaceFolder.settings.label);
-
         const authorizationProcess = this.startAuthorization(workspaceFolder);
         this.connections.set(workspaceFolder, authorizationProcess);
         return authorizationProcess;

--- a/src/projects/extension/authorization/authorization.helper.ts
+++ b/src/projects/extension/authorization/authorization.helper.ts
@@ -16,9 +16,12 @@ interface AuthorizationResult {
 @singleton()
 export class AuthorizationHelper {
 
-    private connections: WeakMap<WorkspaceFolder, EnigmaSession>;
-
     private storage: Storage;
+
+    /**
+     * cache for active connections maybe we could allways return a promise for that
+     */
+    private connections: WeakMap<WorkspaceFolder, Promise<EnigmaSession|undefined>>;
 
     public constructor(
         @inject(AuthorizationService) private authService: AuthorizationService,
@@ -32,22 +35,26 @@ export class AuthorizationHelper {
     }
 
     /**
-     * returns true we have allready a running connection
-     */
-    public isConnected(workspace: WorkspaceFolder): boolean
-    {
-        return this.connections.has(workspace);
-    }
-
-    /**
      * try to authenticate on qlik
      */
     public async authenticate(workspaceFolder: WorkspaceFolder): Promise<EnigmaSession|undefined>
     {
-        if (this.connections.has(workspaceFolder)) {
+        if ( this.isConnected(workspaceFolder)) {
             return this.connections.get(workspaceFolder);
         }
 
+        console.log(workspaceFolder.settings.label);
+
+        const authorizationProcess = this.startAuthorization(workspaceFolder);
+        this.connections.set(workspaceFolder, authorizationProcess);
+        return authorizationProcess;
+    }
+
+    /**
+     * start authorization process
+     */
+    private async startAuthorization(workspaceFolder: WorkspaceFolder): Promise<EnigmaSession|undefined>
+    {
         const settings = workspaceFolder.settings;
         const key      = this.createKey(settings);
         const state    = await this.resolveAuthenticationState(settings, key);
@@ -58,13 +65,17 @@ export class AuthorizationHelper {
         if (result.isLoggedIn) {
             /** update cache */
             this.storage.write(key, {cookies: result?.cookies ?? []});
-
             /** create / save connection */
-            const connection = new EnigmaSession({...workspaceFolder.settings.connection, cookies: result?.cookies ?? []});
-            this.connections.set(workspaceFolder, connection);
-
-            return connection;
+            return new EnigmaSession({...workspaceFolder.settings.connection, cookies: result?.cookies ?? []});
         }
+    }
+
+    /**
+     * check authorization is currently running
+     */
+    private isConnected(workspaceFolder: WorkspaceFolder): boolean
+    {
+        return !!this.connections.has(workspaceFolder);
     }
 
     /**

--- a/src/projects/extension/file-system/entry/qixfs-entry.ts
+++ b/src/projects/extension/file-system/entry/qixfs-entry.ts
@@ -51,8 +51,6 @@ export abstract class QixFsEntry {
         if (workspaceFolder) {
             return await this.authService.authenticate(workspaceFolder);
         }
-
-        console.log("could not resolve workspace folder", uri);
     }
 }
 

--- a/src/projects/extension/workspace/utils/registry.ts
+++ b/src/projects/extension/workspace/utils/registry.ts
@@ -23,8 +23,13 @@ export class WorkspaceFolderRegistry {
 
         for(let i = 0, ln = folders.length; i < ln; i++) {
             const folder  = folders[i];
-            const setting = this.settingsRepository.find(folder.name);
 
+            if (this.workspaceFolders.has(folder.name)) {
+                console.log(folder.name);
+                continue;
+            }
+
+            const setting = this.settingsRepository.find(folder.name);
             if (!setting || folder.uri.scheme !== "qix") {
                 continue;
             }

--- a/src/projects/extension/workspace/utils/registry.ts
+++ b/src/projects/extension/workspace/utils/registry.ts
@@ -25,7 +25,6 @@ export class WorkspaceFolderRegistry {
             const folder  = folders[i];
 
             if (this.workspaceFolders.has(folder.name)) {
-                console.log(folder.name);
                 continue;
             }
 


### PR DESCRIPTION
fixed issue if we added a new workspace folder which requires login credentials, there was multiple authoriaztion calls in hsort time. Which causes the error that we open to many user sessions on qlik sense sever. Now we cache the connections (pending or solved) in authorization helper and return this ones.

closes #273