### PR TITLE
refactoring to modules

### DIFF
--- a/src/projects/extension/connection/api/index.ts
+++ b/src/projects/extension/connection/api/index.ts
@@ -1,6 +1,8 @@
 import { AuthorizationSetting } from "projects/extension/authorization/api";
 import { Storage } from "@core/storage";
 import { AuthorizationStrategyConstructor } from "../../authorization/strategies/authorization.strategy";
+import { InjectionToken } from "tsyringe";
+import { VsQlikLogger } from "@vsqlik/logger";
 
 export interface DisplaySettings {
     dimensions: boolean;
@@ -82,3 +84,10 @@ export interface ConnectionConfiguration {
      */
     storage?: Storage;
 }
+
+export const enum COMMANDS {
+    CONNECT = 'VsQlik.Connection.Connect',
+    DISCONNECT = 'VsQlik.Connection.Disconnect',
+}
+
+export const VsQlikLoggerConnection: InjectionToken<VsQlikLogger> = `VsQlik Logger Connection`;

--- a/src/projects/extension/connection/commands/add.ts
+++ b/src/projects/extension/connection/commands/add.ts
@@ -18,6 +18,7 @@ export async function AddConnectionCommand(): Promise<void> {
             vscode.window.showInformationMessage(`Workspacefolder ${name} allready exists.`);
             return;
         }
+
         vscode.workspace.updateWorkspaceFolders(vscode.workspace.workspaceFolders?.length ?? 0, 0, newWorkspaceFolder);
     }
 }

--- a/src/projects/extension/connection/commands/disconnect.ts
+++ b/src/projects/extension/connection/commands/disconnect.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { container } from 'tsyringe';
 import { ConnectionProvider } from '../utils/connection.provider';
-import { VsQlikLoggerConnection } from '@vsqlik/logger/api';
+import { VsQlikLoggerConnection } from '../api';
 
 export function ServerDisconnectCommand(workspace: vscode.WorkspaceFolder): void {
     const connectionProvider = container.resolve(ConnectionProvider);

--- a/src/projects/extension/connection/commands/index.ts
+++ b/src/projects/extension/connection/commands/index.ts
@@ -1,0 +1,5 @@
+export * from "./add";
+export * from "./connect";
+export * from "./disconnect";
+export * from "./fetch-server-informations";
+export * from "./remove";

--- a/src/projects/extension/connection/connection.module.ts
+++ b/src/projects/extension/connection/connection.module.ts
@@ -1,0 +1,54 @@
+import { ConnectionStorage, ExtensionContext } from "@data/tokens";
+import * as vscode from "vscode";
+import { FileStorage, MemoryStorage } from "@core/storage";
+import { SettingsOpenCommand } from "@settings";
+import { LoggerFactory } from "@vsqlik/logger";
+import { container, inject, singleton } from "tsyringe";
+import { COMMANDS, VsQlikLoggerConnection } from "./api";
+import { AddConnectionCommand, ServerConnectCommand, ServerDisconnectCommand, RemoveConnectionCommand } from "./commands";
+
+@singleton()
+export class ConnectionModule {
+
+    constructor(
+        @inject(ExtensionContext) private extensionContext: vscode.ExtensionContext
+    ) {}
+
+    /**
+     * bootstrap connection module
+     */
+    public bootstrap(): void {
+        this.registerCommands();
+        this.createConnectionStorage();
+        this.registerLogger();
+    }
+
+    private registerLogger() {
+        container.register(VsQlikLoggerConnection, { useFactory: LoggerFactory(`VsQlik Connection`) });
+    }
+
+    /**
+     * register commands for vscode
+     */
+    private registerCommands(): void {
+        vscode.commands.registerCommand('VsQlik.Connection.Create',   AddConnectionCommand);
+        vscode.commands.registerCommand('VsQlik.Connection.Settings', SettingsOpenCommand);
+
+        this.extensionContext.subscriptions.push(vscode.commands.registerCommand(COMMANDS.CONNECT, ServerConnectCommand));
+        this.extensionContext.subscriptions.push(vscode.commands.registerCommand(COMMANDS.DISCONNECT, ServerDisconnectCommand));
+        this.extensionContext.subscriptions.push(vscode.commands.registerCommand('VsQlik.Connection.Remove', RemoveConnectionCommand));
+    }
+
+    /**
+     * register connection storage where all sessions are saved to
+     */
+    private createConnectionStorage(): void {
+        const settings: any = vscode.workspace.getConfiguration().get('VsQlik.Developer');
+        const storage = settings.cacheSession
+            ? new FileStorage(this.extensionContext.globalStoragePath, "auth.json")
+            : new MemoryStorage();
+
+        /** register connection storage */
+        container.register(ConnectionStorage, {useValue: storage});
+    }
+}

--- a/src/projects/extension/connection/index.ts
+++ b/src/projects/extension/connection/index.ts
@@ -1,6 +1,5 @@
 export * from "./api";
-export * from "./commands/add";
-export * from "./commands/remove";
 export * from "./utils/connection.helper";
 export * from "./utils/enigma.provider";
 export * from "./utils/connection.provider";
+export * from "./connection.module";

--- a/src/projects/extension/connection/utils/connection.ts
+++ b/src/projects/extension/connection/utils/connection.ts
@@ -10,12 +10,13 @@ import { AuthorizationState } from "@auth/strategies/authorization.strategy";
 
 import { WorkspaceSetting } from "@vsqlik/settings/api";
 import { FileSystemStorage } from "@vsqlik/fs/utils/file-system.storage";
-import { VsQlikLogger, VsQlikLoggerConnection } from "@vsqlik/logger";
+import { VsQlikLogger } from "@vsqlik/logger";
 
 import { ConnectionState, ConnectionModel } from "../model/connection";
 import { ConnectionHelper } from "./connection.helper";
 import { EnigmaSession } from "./enigma.provider";
-import { fetchServerInformation } from "../commands/fetch-server-informations";
+import { VsQlikLoggerConnection } from "../api";
+import { fetchServerInformation } from "../commands";
 
 /**
  * represents the connection to a server, which is a workspace folder in vscode

--- a/src/projects/extension/data/tokens.ts
+++ b/src/projects/extension/data/tokens.ts
@@ -1,8 +1,9 @@
-import { InjectionToken } from "tsyringe";
+import { container, InjectionToken } from "tsyringe";
 import * as vscode from "vscode";
-import { Storage } from '@core/storage';
+import {Storage } from '@core/storage';
 
 export const ExtensionContext: InjectionToken<vscode.ExtensionContext> = "VsCodeExtensionContext";
+export const ExtensionCache: InjectionToken<Storage> = "local Extension Cache";
 export const WorkspaceFolders: InjectionToken<string[]> = "VsCodeWorkspaceFolders";
 export const VsQlikServerSettings: InjectionToken<string> = "VsQlik Server Settings in settings.json file";
 export const VsQlikDevSettings: InjectionToken<string> = "VsQlik Developer Settings key in settings.json file";

--- a/src/projects/extension/file-system/index.ts
+++ b/src/projects/extension/file-system/index.ts
@@ -1,0 +1,1 @@
+export * from "./qix-fs.module";

--- a/src/projects/extension/file-system/qix-fs.module.ts
+++ b/src/projects/extension/file-system/qix-fs.module.ts
@@ -1,0 +1,69 @@
+import { QixRouter } from "@core/router";
+import { ExtensionContext } from "@data/tokens";
+import { VsQlikLoggerGlobal } from "@vsqlik/logger";
+import { container, inject, singleton } from "tsyringe";
+import * as vscode from "vscode";
+import { COMMANDS as ConnectionCommands } from "../connection/api";
+import { Routes } from "./data";
+import { QixFSProvider } from "./utils/qix-fs.provider";
+
+@singleton()
+export class QixFsModule {
+
+    constructor(
+        @inject(ExtensionContext) private extensionContext: vscode.ExtensionContext,
+        @inject(QixRouter) private router: QixRouter<any>
+    ) {}
+
+    public bootstrap(): void {
+        this.registerQixFs();
+        this.router.addRoutes(Routes);
+    }
+
+    public initialize(): void {
+        this.registerEvents();
+
+        /**
+         * register existing workspace folders (for example close and reopen editor)
+         * fs or connect good question
+         */
+        vscode.workspace.workspaceFolders?.forEach((folder) => {
+            if (folder.uri.scheme === 'qix') {
+                vscode.commands.executeCommand(ConnectionCommands.CONNECT, folder);
+            }
+        });
+    }
+
+    /**
+     * register to filesystem changes
+     */
+    private registerEvents(): void {
+
+        vscode.workspace.onDidChangeWorkspaceFolders((event) => {
+            const logger = container.resolve(VsQlikLoggerGlobal);
+            event.added.forEach((folder) => {
+                if(folder.uri.scheme === 'qix') {
+                    logger.info(`added workspace folder ${folder.name}`);
+                    vscode.commands.executeCommand(ConnectionCommands.CONNECT, folder);
+                }
+            });
+
+            event.removed.forEach((folder) => {
+                if(folder.uri.scheme === 'qix') {
+                    logger.info(`removed workspace folder ${folder.name}`);
+                    vscode.commands.executeCommand(ConnectionCommands.DISCONNECT, folder);
+                }
+            });
+        });
+    }
+
+    /**
+     * register qix file system provider to vscode
+     */
+    private registerQixFs(): void {
+        /** register qixfs provider */
+        const qixFs = new QixFSProvider();
+        this.extensionContext.subscriptions.push(
+            vscode.workspace.registerFileSystemProvider('qix', qixFs, { isCaseSensitive: true }));
+    }
+}

--- a/src/projects/extension/logger/api.ts
+++ b/src/projects/extension/logger/api.ts
@@ -36,12 +36,11 @@ container.register(VsQlikLogSettings, {
 /**
  * logger
  */
-export const VsQlikLoggerConnection: InjectionToken<VsQlikLogger> = `VsQlik Logger Connection`;
 export const VsQlikLoggerScript: InjectionToken<VsQlikLogger>     = `VsQlik Logger Script`;
 export const VsQlikLoggerQixFs: InjectionToken<VsQlikLogger>      = `VsQlik Logger Qix FS`;
 export const VsQlikLoggerGlobal: InjectionToken<VsQlikLogger>     = `VsQlik Global Logger`;
 
-function LoggerFactory(label: string) {
+export function LoggerFactory(label: string): () => VsQlikLogger {
     const resolver = container.resolve(VsQlikLoggerResolver);
     const token    = new VsQlikLoggerToken(label);
 
@@ -49,6 +48,5 @@ function LoggerFactory(label: string) {
 }
 
 container.register(VsQlikLoggerGlobal,     { useFactory: LoggerFactory(`VsQlik`) });
-container.register(VsQlikLoggerConnection, { useFactory: LoggerFactory(`VsQlik.Connection`) });
 container.register(VsQlikLoggerQixFs,      { useFactory: LoggerFactory(`VsQlik.QixFS`) });
 container.register(VsQlikLoggerScript,     { useFactory: LoggerFactory(`VsQlik.Script`) });

--- a/src/projects/extension/main.ts
+++ b/src/projects/extension/main.ts
@@ -1,20 +1,14 @@
 import "reflect-metadata";
 import * as vscode from "vscode";
 import { container } from "tsyringe";
-import { QixRouter } from "@shared/router";
 
-import { SettingsOpenCommand, SettingsUpdateCommand } from "@settings";
-import { Routes } from "@vsqlik/fs/data";
+import { SettingsUpdateCommand } from "@settings";
 import { VsQlikLoggerGlobal } from "@vsqlik/logger";
-import { ExtensionContext, VsQlikServerSettings, VsQlikDevSettings, ConnectionStorage, QlikOutputChannel } from "./data/tokens";
-import { FileStorage, MemoryStorage } from "@core/storage";
-import { AddConnectionCommand, RemoveConnectionCommand } from "./connection";
-import { QixFSProvider } from "./file-system/utils/qix-fs.provider";
-import { ServerConnectCommand } from "./connection/commands/connect";
-import { ServerDisconnectCommand } from "./connection/commands/disconnect";
-import { CheckScriptSyntax } from "./script/commands/check-syntax";
-import { ScriptLoadDataCommand } from "./script";
-import { ScriptResolveActiveCommand } from "./script/commands/active-script";
+import { ConnectionModule } from "@vsqlik/connection";
+import { QixFsModule } from "@vsqlik/qixfs";
+import { ScriptModule } from "@vsqlik/script";
+
+import { ExtensionContext, VsQlikServerSettings, VsQlikDevSettings, QlikOutputChannel } from "./data/tokens";
 
 /**
  * bootstrap extension
@@ -30,33 +24,20 @@ export function activate(context: vscode.ExtensionContext): void {
 
     container.register(QlikOutputChannel, { useFactory: outputChannelFactory() });
 
-    /** register connection storage */
-    container.register(ConnectionStorage, {
-        useFactory: () => {
-            const settings: any = vscode.workspace.getConfiguration().get('VsQlik.Developer');
-            return settings.cacheSession
-                ? new FileStorage(context.globalStoragePath, "auth.json")
-                : new MemoryStorage();
-        }
-    });
+    /** resolve modules */
+    const connectionModule = container.resolve(ConnectionModule);
+    const qixFsModule      = container.resolve(QixFsModule);
+    const scriptModule     = container.resolve(ScriptModule);
 
-    /** register routes */
-    container.resolve(QixRouter).addRoutes(Routes);
+    /** bootstrap modules */
+    connectionModule.bootstrap();
+    qixFsModule.bootstrap();
+    scriptModule.bootstrap();
 
-    /** register qixfs provider */
-    const qixFs = new QixFSProvider();
-    context.subscriptions.push(vscode.workspace.registerFileSystemProvider('qix', qixFs, { isCaseSensitive: true }));
+    /** initialize modules */
+    qixFsModule.initialize();
 
     registerCommands(context);
-    registerEvents();
-    registerWorkspacefolderEvents();
-
-    /** register existing workspace folders (for example close and reopen editor) */
-    vscode.workspace.workspaceFolders?.forEach((folder) => {
-        if (folder.uri.scheme === 'qix') {
-            vscode.commands.executeCommand('VsQlik.Connection.Connect', folder);
-        }
-    });
 
     container.resolve(VsQlikLoggerGlobal).info(`extension activated`);
 }
@@ -66,25 +47,7 @@ export function activate(context: vscode.ExtensionContext): void {
  */
 function registerCommands(context: vscode.ExtensionContext) {
     /** register commands */
-    vscode.commands.registerCommand('VsQlik.Connection.Create',   AddConnectionCommand);
-    vscode.commands.registerCommand('VsQlik.Connection.Settings', SettingsOpenCommand);
-
-    context.subscriptions.push(vscode.commands.registerCommand('VsQlik.Connection.Connect', ServerConnectCommand));
-    context.subscriptions.push(vscode.commands.registerCommand('VsQlik.Connection.Disconnect', ServerDisconnectCommand));
-    context.subscriptions.push(vscode.commands.registerCommand('VsQlik.Connection.Remove', RemoveConnectionCommand));
     context.subscriptions.push(vscode.commands.registerCommand('VsQlik.Settings.Update', SettingsUpdateCommand));
-
-    context.subscriptions.push(vscode.commands.registerCommand('VsQlik.Script.CheckSyntax', CheckScriptSyntax));
-    context.subscriptions.push(vscode.commands.registerCommand('VsQlik.Script.LoadData', ScriptLoadDataCommand));
-    context.subscriptions.push(vscode.commands.registerCommand('VsQlik.Script.ResolveActive', ScriptResolveActiveCommand));
-}
-
-function registerEvents() {
-    vscode.workspace.onDidOpenTextDocument((doc: vscode.TextDocument) => {
-        doc.fileName.match(/\.qvs$/)
-            ? vscode.commands.executeCommand(`VsQlik.Script.CheckSyntax`, doc.uri)
-            : void 0;
-    });
 }
 
 function outputChannelFactory(): () => vscode.OutputChannel {
@@ -95,31 +58,6 @@ function outputChannelFactory(): () => vscode.OutputChannel {
         }
         return channel;
     };
-}
-
-/**
- * listen to workspace folder events (added / removed)
- */
-function registerWorkspacefolderEvents() {
-
-    vscode.workspace.onDidChangeWorkspaceFolders((event) => {
-
-        const logger = container.resolve(VsQlikLoggerGlobal);
-
-        event.added.forEach((folder) => {
-            if(folder.uri.scheme === 'qix') {
-                logger.info(`added workspace folder ${folder.name}`);
-                vscode.commands.executeCommand('VsQlik.Connection.Connect', folder);
-            }
-        });
-
-        event.removed.forEach((folder) => {
-            if(folder.uri.scheme === 'qix') {
-                logger.info(`removed workspace folder ${folder.name}`);
-                vscode.commands.executeCommand('VsQlik.Connection.Disconnect', folder);
-            }
-        });
-    });
 }
 
 export function deactivate(): void {

--- a/src/projects/extension/script/commands/index.ts
+++ b/src/projects/extension/script/commands/index.ts
@@ -1,0 +1,3 @@
+export * from "./active-script";
+export * from "./check-syntax";
+export * from "./load-data";

--- a/src/projects/extension/script/index.ts
+++ b/src/projects/extension/script/index.ts
@@ -1,1 +1,1 @@
-export * from "./commands/load-data";
+export * from "./script.module";

--- a/src/projects/extension/script/script.module.ts
+++ b/src/projects/extension/script/script.module.ts
@@ -1,0 +1,37 @@
+import { ExtensionContext } from "@data/tokens";
+import * as vscode from "vscode";
+import { inject, singleton } from "tsyringe";
+import { CheckScriptSyntax, ScriptLoadDataCommand, ScriptResolveActiveCommand } from "./commands";
+
+@singleton()
+export class ScriptModule {
+
+    constructor(
+        @inject(ExtensionContext) private extensionContext: vscode.ExtensionContext
+    ) {}
+
+    public bootstrap(): void {
+        this.registerCommands();
+        this.registerEvents();
+    }
+
+    /**
+     * register commands for vscode
+     */
+    private registerCommands(): void {
+        this.extensionContext.subscriptions.push(vscode.commands.registerCommand('VsQlik.Script.CheckSyntax', CheckScriptSyntax));
+        this.extensionContext.subscriptions.push(vscode.commands.registerCommand('VsQlik.Script.LoadData', ScriptLoadDataCommand));
+        this.extensionContext.subscriptions.push(vscode.commands.registerCommand('VsQlik.Script.ResolveActive', ScriptResolveActiveCommand));
+    }
+
+    /**
+     * register connection storage where all sessions are saved to
+     */
+    private registerEvents(): void {
+        vscode.workspace.onDidOpenTextDocument((doc: vscode.TextDocument) => {
+            if(doc.fileName.match(/\.qvs$/)) {
+                vscode.commands.executeCommand(`VsQlik.Script.CheckSyntax`, doc.uri);
+            }
+        });
+    }
+}

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -35,6 +35,10 @@
 
       "@vsqlik/logger": ["projects/extension/logger"],
       "@vsqlik/logger/*": ["projects/extension/logger/*"],
+
+      "@vsqlik/connection": ["projects/extension/connection"],
+      "@vsqlik/qixfs": ["projects/extension/file-system"],
+      "@vsqlik/script": ["projects/extension/script"]
     }
   },
   "exclude": [


### PR DESCRIPTION
since the main.ts was blown up andn we lost a bit of control refactor to handle modules which bootstraps and register events by own. This also ensures code gets not mixed up that much.