### PR TITLE
fix: fixed bug we connected twice if added a qix directory

### DIFF
--- a/src/projects/extension/connection/connection.module.ts
+++ b/src/projects/extension/connection/connection.module.ts
@@ -2,13 +2,15 @@ import { ConnectionStorage, ExtensionContext } from "@data/tokens";
 import * as vscode from "vscode";
 import { FileStorage, MemoryStorage } from "@core/storage";
 import { SettingsOpenCommand } from "@settings";
-import { LoggerFactory } from "@vsqlik/logger";
+import { LoggerFactory, VsQlikLogger } from "@vsqlik/logger";
 import { container, inject, singleton } from "tsyringe";
 import { COMMANDS, VsQlikLoggerConnection } from "./api";
 import { AddConnectionCommand, ServerConnectCommand, ServerDisconnectCommand, RemoveConnectionCommand } from "./commands";
 
 @singleton()
 export class ConnectionModule {
+
+    private logger: VsQlikLogger;
 
     constructor(
         @inject(ExtensionContext) private extensionContext: vscode.ExtensionContext
@@ -21,6 +23,23 @@ export class ConnectionModule {
         this.registerCommands();
         this.createConnectionStorage();
         this.registerLogger();
+    }
+
+    public initialize(): void {
+        this.logger = container.resolve(VsQlikLoggerConnection);
+
+        /**
+         * register existing workspace folders (for example close and reopen editor)
+         * fs or connect good question
+         */
+        vscode.workspace.workspaceFolders?.forEach((folder) => {
+            if (folder.uri.scheme === 'qix') {
+                this.logger.info(`found existing qix workspace folder ${folder.name}`);
+                vscode.commands.executeCommand(COMMANDS.CONNECT, folder);
+            }
+        });
+
+        this.registerOnWorkspaceChanges();
     }
 
     private registerLogger() {
@@ -50,5 +69,37 @@ export class ConnectionModule {
 
         /** register connection storage */
         container.register(ConnectionStorage, {useValue: storage});
+    }
+
+    /**
+     * register workspace folder events to get notified about our active connections
+     */
+    private registerOnWorkspaceChanges() {
+
+        vscode.workspace.onDidChangeWorkspaceFolders((event) => {
+            event.added.forEach((folder) => {
+                if(folder.uri.scheme === 'qix') {
+                    /**
+                     * if we handle an empty workspace and added 1 folder (qix) the extension host
+                     * will restart soon and then find a qix fs and try to connect to it.
+                     *
+                     * So we ignore this if we have only 1 workspace folder to avoid 1 connection
+                     * which is not required.
+                     */
+                    this.logger.info(`add qix workspace folder ${folder.name}`);
+                    const qixWorkspaceFolders = vscode.workspace.workspaceFolders?.filter((folder) => folder.uri.scheme === 'qix') ?? [];
+                    if (qixWorkspaceFolders.length > 1) {
+                        vscode.commands.executeCommand(COMMANDS.CONNECT, folder);
+                    }
+                }
+            });
+
+            event.removed.forEach((folder) => {
+                if(folder.uri.scheme === 'qix') {
+                    this.logger.info(`remove qix workspace folder ${folder.name}`);
+                    vscode.commands.executeCommand(COMMANDS.DISCONNECT, folder);
+                }
+            });
+        });
     }
 }

--- a/src/projects/extension/file-system/qix-fs.module.ts
+++ b/src/projects/extension/file-system/qix-fs.module.ts
@@ -20,43 +20,6 @@ export class QixFsModule {
         this.router.addRoutes(Routes);
     }
 
-    public initialize(): void {
-        this.registerEvents();
-
-        /**
-         * register existing workspace folders (for example close and reopen editor)
-         * fs or connect good question
-         */
-        vscode.workspace.workspaceFolders?.forEach((folder) => {
-            if (folder.uri.scheme === 'qix') {
-                vscode.commands.executeCommand(ConnectionCommands.CONNECT, folder);
-            }
-        });
-    }
-
-    /**
-     * register to filesystem changes
-     */
-    private registerEvents(): void {
-
-        vscode.workspace.onDidChangeWorkspaceFolders((event) => {
-            const logger = container.resolve(VsQlikLoggerGlobal);
-            event.added.forEach((folder) => {
-                if(folder.uri.scheme === 'qix') {
-                    logger.info(`added workspace folder ${folder.name}`);
-                    vscode.commands.executeCommand(ConnectionCommands.CONNECT, folder);
-                }
-            });
-
-            event.removed.forEach((folder) => {
-                if(folder.uri.scheme === 'qix') {
-                    logger.info(`removed workspace folder ${folder.name}`);
-                    vscode.commands.executeCommand(ConnectionCommands.DISCONNECT, folder);
-                }
-            });
-        });
-    }
-
     /**
      * register qix file system provider to vscode
      */

--- a/src/projects/extension/main.ts
+++ b/src/projects/extension/main.ts
@@ -35,7 +35,7 @@ export function activate(context: vscode.ExtensionContext): void {
     scriptModule.bootstrap();
 
     /** initialize modules */
-    qixFsModule.initialize();
+    connectionModule.initialize();
 
     registerCommands(context);
 


### PR DESCRIPTION
this happens if we added our first qix directory to workspace, so if allready a qix directory exists the extension host does not restart otherwise it does.

closes #602