### PR TITLE
fix: fixed bug visible elements not shown if not defined

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -109,8 +109,9 @@
                 "dimensions": true,
                 "measures": true,
                 "script": true,
-                "sheets": false,
-                "variables": false
+                "sheets": true,
+                "variables": true,
+                "visualization": true
               }
             }]
           }

--- a/src/projects/extension/connection/api/index.ts
+++ b/src/projects/extension/connection/api/index.ts
@@ -10,6 +10,7 @@ export interface DisplaySettings {
     script: boolean;
     sheets: boolean;
     variables: boolean;
+    visualization: boolean;
 }
 
 /** connection settings */

--- a/src/projects/extension/file-system/entry/application/app.directory.ts
+++ b/src/projects/extension/file-system/entry/application/app.directory.ts
@@ -3,6 +3,7 @@ import { inject } from "tsyringe";
 import { posix } from "path";
 import { QixApplicationProvider } from "@shared/qix/utils/application.provider";
 import { QixFsDirectoryAdapter } from "../qix/qixfs-entry";
+import { DisplaySettings } from "@core/public.api";
 
 /** */
 export class ApplicationDirectory extends QixFsDirectoryAdapter {
@@ -11,6 +12,15 @@ export class ApplicationDirectory extends QixFsDirectoryAdapter {
         @inject(QixApplicationProvider) private appService: QixApplicationProvider,
     ) {
         super();
+    }
+
+    private defaultDisplaySettings: DisplaySettings = {
+        dimensions: true,
+        measures: true,
+        script: true,
+        sheets: true,
+        variables: true,
+        visualization: true
     }
 
     /**
@@ -22,7 +32,15 @@ export class ApplicationDirectory extends QixFsDirectoryAdapter {
         const connection = await this.getConnection(uri);
 
         if (connection) {
-            const settings = {...connection.serverSettings.display, visualization: true};
+
+            const settings = {
+                ...this.defaultDisplaySettings,
+                ...connection.serverSettings.display ?? {},
+            };
+
+            /**
+             * what if the settings simply not exists
+             */
             Object.keys(settings).forEach((key) => {
                 if (settings[key] !== false) {
                     folders.push([key, vscode.FileType.Directory]);

--- a/src/projects/media/webview/projects/connection/src/app/data/api.ts
+++ b/src/projects/media/webview/projects/connection/src/app/data/api.ts
@@ -82,6 +82,8 @@ export interface DisplaySettings {
     sheets: boolean;
 
     variables: boolean;
+
+    visualization: boolean;
 }
 
 export interface WorkspaceFolderSetting {

--- a/src/projects/media/webview/projects/connection/src/app/ui/edit/display.ts
+++ b/src/projects/media/webview/projects/connection/src/app/ui/edit/display.ts
@@ -17,7 +17,14 @@ export class DisplaySettingsComponent implements OnInit, OnDestroy {
 
     public displayFormGroup: FormGroup;
 
-    public displayFields = ["dimensions", "measures", "script", "sheets", "variables"];
+    public displayFields = [
+      "dimensions",
+      "measures",
+      "script",
+      "sheets",
+      "variables",
+      "visualization"
+    ];
 
     /**
      * emits true if component gets destroyed
@@ -65,11 +72,12 @@ export class DisplaySettingsComponent implements OnInit, OnDestroy {
      */
     private createForm(setting: DisplaySettings): FormGroup {
         return this.formbuilder.group({
-            dimensions: this.formbuilder.control(setting.dimensions),
-            measures: this.formbuilder.control(setting.measures),
-            script: this.formbuilder.control(setting.script),
-            sheets: this.formbuilder.control(setting.sheets),
-            variables: this.formbuilder.control(setting.variables),
+            dimensions: this.formbuilder.control(setting?.dimensions ?? true),
+            measures: this.formbuilder.control(setting?.measures ?? true),
+            script: this.formbuilder.control(setting?.script ?? true),
+            sheets: this.formbuilder.control(setting?.sheets ?? true),
+            variables: this.formbuilder.control(setting?.variables ?? true),
+            visualization: this.formbuilder.control(setting?.visualization ?? true),
         });
     }
 

--- a/src/projects/media/webview/projects/connection/src/app/utils/connection-form.helper.ts
+++ b/src/projects/media/webview/projects/connection/src/app/utils/connection-form.helper.ts
@@ -91,6 +91,7 @@ export class ConnectionFormHelper {
               script: true,
               sheets: true,
               variables: true,
+              visualization: true
             },
             label: "New Connection"
         };


### PR DESCRIPTION
fixed a bug by default if the settings display not exists or a setting not exists it was simply not shown. now moving to default if it is not defined it is true and will be visible.
Also moved display.visualization setting to display settings.

closes #487